### PR TITLE
Initial commit of packed decimal support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/.idea/
+**/*.iml
+**/target/

--- a/src/main/java/com/igormaznitsa/jbbp/compiler/JBBPCompiler.java
+++ b/src/main/java/com/igormaznitsa/jbbp/compiler/JBBPCompiler.java
@@ -141,6 +141,12 @@ public final class JBBPCompiler {
   public static final int CODE_RESET_COUNTER = 0x0E;
 
   /**
+   * The Byte code of the binary coded decimal (BCD, aka packed decimal) command.
+   * @since 1.1.1
+   */
+  public static final int CODE_BCD = 0x0F;
+
+  /**
    * The Byte-Code Flag shows that the field is a named one.
    */
   public static final int FLAG_NAMED = 0x10;
@@ -285,6 +291,26 @@ public final class JBBPCompiler {
             }
             if (extraField < 1 || extraField > 8) {
               throw new JBBPCompilationException("Wrong bit number, must be 1..8 [" + token.getFieldTypeParameters().getExtraData() + ']', token);
+            }
+          }
+        }
+        break;
+        case CODE_BCD: {
+          final String parsedNumBytes = token.getFieldTypeParameters().getExtraData();
+          extraFieldPresented = true;
+          if (parsedNumBytes == null) {
+            extraField = 1;
+          }
+          else {
+            try {
+              extraField = Integer.parseInt(parsedNumBytes);
+              assertNonNegativeValue(extraField, token);
+            }
+            catch (NumberFormatException ex) {
+              extraField = -1;
+            }
+            if (extraField < 1 || extraField > 10) {
+              throw new JBBPCompilationException("Wrong number of BCD bytes, must be 1..10 [" + token.getFieldTypeParameters().getExtraData() + ']', token);
             }
           }
         }
@@ -511,6 +537,9 @@ public final class JBBPCompiler {
         }
         else if ("long".equals(name)) {
           result |= CODE_LONG;
+        }
+        else if ("bcd".equals(name)) {
+          result |= CODE_BCD;
         }
         else if ("reset$$".equals(name)) {
           result |= CODE_RESET_COUNTER;

--- a/src/main/java/com/igormaznitsa/jbbp/compiler/tokenizer/JBBPTokenizer.java
+++ b/src/main/java/com/igormaznitsa/jbbp/compiler/tokenizer/JBBPTokenizer.java
@@ -63,6 +63,7 @@ public final class JBBPTokenizer implements Iterable<JBBPToken>, Iterator<JBBPTo
     disabledFieldNames.add("ushort");
     disabledFieldNames.add("int");
     disabledFieldNames.add("long");
+    disabledFieldNames.add("bcd");
     disabledFieldNames.add("$");
   }
 

--- a/src/main/java/com/igormaznitsa/jbbp/exceptions/JBBPOutException.java
+++ b/src/main/java/com/igormaznitsa/jbbp/exceptions/JBBPOutException.java
@@ -1,0 +1,16 @@
+package com.igormaznitsa.jbbp.exceptions;
+
+/**
+ * Thrown when errors occur while using {@link com.igormaznitsa.jbbp.io.JBBPOut}
+ * to create binary block byte arrays.
+ */
+public class JBBPOutException extends JBBPException {
+
+  public JBBPOutException(String message) {
+    super(message);
+  }
+
+  public JBBPOutException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/igormaznitsa/jbbp/io/JBBPPackedDecimalType.java
+++ b/src/main/java/com/igormaznitsa/jbbp/io/JBBPPackedDecimalType.java
@@ -1,0 +1,62 @@
+package com.igormaznitsa.jbbp.io;
+
+/**
+ * Constants for signed and unsigned packed decimal.
+ */
+public enum JBBPPackedDecimalType {
+  /**
+   * Signed with a nibble indicating the sign.  Sign values are according to the following table:
+   * <table>
+   *   <tr>
+   *     <th align="center">Value</th>
+   *     <th align="center">Sign</th>
+   *     <th align="center">Notes</th>
+   *   </tr>
+   *   <tr>
+   *     <td align="center">0xA (1010)</td>
+   *     <td align="center">+</td>
+   *     <td align="center">&nbsp;</td>
+   *   </tr>
+   *   <tr>
+   *     <td align="center">0xB (1011)</td>
+   *     <td align="center">-</td>
+   *     <td align="center">&nbsp;</td>
+   *   </tr>
+   *   <tr>
+   *     <td align="center">0xC (1100)</td>
+   *     <td align="center">+</td>
+   *     <td align="center">Preferred</td>
+   *   </tr>
+   *   <tr>
+   *     <td align="center">0xD (1101)</td>
+   *     <td align="center">-</td>
+   *     <td align="center">Preferred</td>
+   *   </tr>
+   *   <tr>
+   *     <td align="center">0xE (1110)</td>
+   *     <td align="center">+</td>
+   *     <td align="center">&nbsp;</td>
+   *   </tr>
+   *   <tr>
+   *     <td align="center">0xF (1111)</td>
+   *     <td align="center">+</td>
+   *     <td align="center">Unsigned</td>
+   *   </tr>
+   * </table>
+   */
+  SIGNED,
+  /**
+   * Unsigned.  Numbers with an odd number of digits can be encoded either with
+   * a leading zero nibble, leading zeroes, or with the last nibble set to 0xA or
+   * higher (0xF is standard), which will be ignored.  For example, the number 123
+   * could be encoded either as:
+   * <pre>
+   *   0001 0010 0011 1111
+   * </pre>
+   * or as:
+   * <pre>
+   *   0000 0001 0010 0011
+   * </pre>
+   */
+  UNSIGNED
+}

--- a/src/main/java/com/igormaznitsa/jbbp/mapper/Bin.java
+++ b/src/main/java/com/igormaznitsa/jbbp/mapper/Bin.java
@@ -105,7 +105,15 @@ public @interface Bin {
    * @since 1.1
    */
   int outOrder() default 0;
-  
+
+  /**
+   * Defines the length of the field in bytes (used for variable length non-array types
+   * such as packed decimal).
+   *
+   * @return the length of the field in bytes
+   */
+  int length() default 0;
+
   /**
    * Just either description of the field or some remark.
    * @return the comment as String

--- a/src/main/java/com/igormaznitsa/jbbp/mapper/BinType.java
+++ b/src/main/java/com/igormaznitsa/jbbp/mapper/BinType.java
@@ -63,6 +63,10 @@ public enum BinType {
    */
   LONG(JBBPFieldLong.class, false),
   /**
+   * A Mapping field will be mapped to a parsed packed decimal field.
+   */
+  BCD(JBBPFieldPackedDecimal.class, false),
+  /**
    * A Mapping field will be mapped to a parsed bit array field.
    */
   BIT_ARRAY(JBBPFieldArrayBit.class, true),
@@ -94,6 +98,10 @@ public enum BinType {
    * A Mapping field will be mapped to a parsed long array field.
    */
   LONG_ARRAY(JBBPFieldArrayLong.class, true),
+  /**
+   * A Mapping field will be mapped to a parsed packed decimal array field.
+   */
+  BCD_ARRAY(JBBPFieldArrayPackedDecimal.class, true),
   /**
    * A Mapping field will be mapped to a parsed structure field.
    */

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayPackedDecimal.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayPackedDecimal.java
@@ -1,0 +1,77 @@
+package com.igormaznitsa.jbbp.model;
+
+import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
+import com.igormaznitsa.jbbp.utils.JBBPUtils;
+
+/**
+ * Describes a packed binary coded decimal array.
+ * @see <a href="http://en.wikipedia.org/wiki/Binary-coded_decimal#Packed_BCD">Packed BCD (Wikipedia)</a>
+ *
+ * @since 1.1.1
+ */
+public class JBBPFieldArrayPackedDecimal extends JBBPAbstractArrayField<JBBPFieldPackedDecimal> {
+  private static final long serialVersionUID = 1L;
+  /**
+   * Inside value storage.
+   */
+  private final long [] array;
+
+  /**
+   * The Constructor.
+   * @param name a field name info, it can be null
+   * @param array a value array, it must not be null
+   */
+  public JBBPFieldArrayPackedDecimal(final JBBPNamedFieldInfo name, final long[] array) {
+    super(name);
+    JBBPUtils.assertNotNull(array, "Array must not be null");
+    this.array = array;
+  }
+
+  /**
+   * get the value array
+   * @return the value array as a long array
+   */
+  public long [] getArray(){
+    return this.array.clone();
+  }
+
+  @Override
+  public int size() {
+    return this.array.length;
+  }
+
+  @Override
+  public JBBPFieldPackedDecimal getElementAt(int index) {
+    return new JBBPFieldPackedDecimal(this.fieldNameInfo, this.array[index]);
+  }
+
+  @Override
+  public int getAsInt(int index) {
+    return (int)this.array[index];
+  }
+
+  @Override
+  public long getAsLong(int index) {
+    return this.array[index];
+  }
+
+  @Override
+  public boolean getAsBool(int index) {
+    return this.array[index]!=0L;
+  }
+
+  @Override
+  public Object getValueArrayAsObject(boolean reverseBits) {
+    final long[] result;
+    if (reverseBits) {
+      result = this.array.clone();
+      for (int i = 0; i < result.length; i++) {
+        result[i] = JBBPFieldLong.reverseBits(result[i]);
+      }
+    }
+    else {
+      result = this.array.clone();
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldPackedDecimal.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldPackedDecimal.java
@@ -1,0 +1,59 @@
+package com.igormaznitsa.jbbp.model;
+
+import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
+import com.igormaznitsa.jbbp.utils.JBBPUtils;
+
+/**
+ * Describes a packed binary coded decimal (BCD) field.
+ * @see <a href="http://en.wikipedia.org/wiki/Binary-coded_decimal#Packed_BCD">Packed BCD (Wikipedia)</a>
+ *
+ * @since 1.1.1
+ */
+public class JBBPFieldPackedDecimal extends JBBPAbstractField implements JBBPNumericField {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Inside value storage.
+   */
+  private final long value;
+
+  /**
+   * The COnstructor.
+   * @param name a field name info, it can be null
+   * @param value the field value
+   */
+  public JBBPFieldPackedDecimal(final JBBPNamedFieldInfo name, final long value) {
+    super(name);
+    this.value = value;
+  }
+
+  public long getValue() {
+    return value;
+  }
+
+  public int getAsInt() {
+    return (int)this.value;
+  }
+
+  public long getAsLong() {
+    return this.value;
+  }
+
+  public boolean getAsBool() {
+    return this.value != 0;
+  }
+
+  /**
+   * Get the reversed bit representation of the value.
+   *
+   * @param value the value to be reversed
+   * @return the reversed value
+   */
+  public static long reverseBits(final long value) {
+    return JBBPFieldLong.reverseBits(value);
+  }
+
+  public long getAsInvertedBitOrder() {
+    return reverseBits(this.value);
+  }
+}

--- a/src/main/java/com/igormaznitsa/jbbp/utils/PackedDecimalUtils.java
+++ b/src/main/java/com/igormaznitsa/jbbp/utils/PackedDecimalUtils.java
@@ -1,0 +1,75 @@
+package com.igormaznitsa.jbbp.utils;
+
+import com.igormaznitsa.jbbp.exceptions.JBBPOutException;
+import com.igormaznitsa.jbbp.io.JBBPByteOrder;
+import com.igormaznitsa.jbbp.io.JBBPPackedDecimalType;
+
+import java.io.IOException;
+
+/**
+ * Collections of methods for handling packed decimal (BCD).  All methods are thread-safe.
+ */
+public class PackedDecimalUtils {
+
+  public long readValueFromPackedDecimal(final byte[] bytes, final JBBPPackedDecimalType type) {
+
+    // read the numeric digits
+    StringBuilder digitStr = new StringBuilder();
+    for (int i = 0; i < bytes.length * 2; i++) {
+
+      byte currentByte = bytes[i / 2];
+
+      // even values of i use high nibble, odd values use low nibble
+      byte digit = (i % 2 == 0) ? (byte)((currentByte & 0xff) >>> 4) : (byte)(currentByte & 0x0f);
+      if (digit < 10) {
+        digitStr.append(digit);
+      }
+    }
+
+    // read the sign
+    if (type.equals(JBBPPackedDecimalType.SIGNED)) {
+      byte sign = (byte)(bytes[bytes.length-1] & 0x0f);
+      if (sign == 0x0b || sign == 0x0d) {
+        digitStr.insert(0, '-');
+      }
+    }
+
+    return Long.parseLong(digitStr.toString());
+  }
+
+  public byte[] writeValueToPackedDecimal(final int length, final long value, final JBBPPackedDecimalType type) throws IOException {
+
+    // validate sign
+    boolean signed = type.equals(JBBPPackedDecimalType.SIGNED);
+    if (value < 0 && !signed) {
+      throw new JBBPOutException("Packed decimal set to UNSIGNED, but value is negative: " + value);
+    }
+
+    // validate length (sign requires one nibble)
+    String valueStr = Long.toString(value).replaceFirst("-", "");
+    int digits = valueStr.length();
+    if ((signed && digits > ((length*2) - 1)) || (!signed && digits > (length*2))) {
+      throw new JBBPOutException("Number of digits in value exceeds packed binary capacity using " + length + " bytes");
+    }
+
+    // create array with one byte per digit, plus optional sign
+    byte[] temp = new byte[length*2]; // elements get initialized to 0
+    int startIdx = signed ? ((length*2) - 1) - digits : (length*2) - digits;
+    for (int i = startIdx; i < (startIdx + digits); i++) {
+      temp[i] = Byte.parseByte(Character.toString(valueStr.charAt(i-startIdx)));
+    }
+    if (signed) {
+      if (value < 0)
+        temp[temp.length-1] = 0xD;
+      else
+        temp[temp.length-1] = 0xC;
+    }
+
+    // pack into nibbles
+    byte[] outArray = new byte[length];
+    for (int i = 0; i < temp.length; i+=2) {
+      outArray[i/2] = (byte)((temp[i] << 4) | temp[i+1]);
+    }
+    return outArray;
+  }
+}

--- a/src/test/java/com/igormaznitsa/jbbp/JBBPParserTest.java
+++ b/src/test/java/com/igormaznitsa/jbbp/JBBPParserTest.java
@@ -263,6 +263,33 @@ public class JBBPParserTest {
     assertEquals(0x0807060504030201L, result.findFieldForType(JBBPFieldLong.class).getAsLong());
   }
 
+  @Test(expected = EOFException.class)
+  public void testParse_PackedDecimal_ErrorForEOF() throws Exception {
+    final JBBPParser parser = JBBPParser.prepare("long;");
+    parser.parse(new byte[0]);
+  }
+
+  @Test
+  public void testParse_SingleDefaultNonamedPackedDecimal_Default() throws Exception {
+    final JBBPParser parser = JBBPParser.prepare("bcd:4;");
+    final JBBPFieldStruct result = parser.parse(new byte[]{0x12, 0x34, 0x56, 0x7F});
+    assertEquals(1234567L, result.findFieldForType(JBBPFieldPackedDecimal.class).getAsLong());
+  }
+
+  @Test
+  public void testParse_SingleDefaultNonamedPackedDecimal_BigEndian() throws Exception {
+    final JBBPParser parser = JBBPParser.prepare(">bcd:4;");
+    final JBBPFieldStruct result = parser.parse(new byte[]{0x12, 0x34, 0x56, 0x7F});
+    assertEquals(1234567L, result.findFieldForType(JBBPFieldPackedDecimal.class).getAsLong());
+  }
+
+  @Test // little endian ignored, uses big endian
+  public void testParse_SingleDefaultNonamedPackedDecimal_LittleEndian() throws Exception {
+    final JBBPParser parser = JBBPParser.prepare(">bcd:4;");
+    final JBBPFieldStruct result = parser.parse(new byte[]{0x12, 0x34, 0x56, 0x7F});
+    assertEquals(1234567L, result.findFieldForType(JBBPFieldPackedDecimal.class).getAsLong());
+  }
+
   @Test
   public void testParse_SingleNonamedVar() throws Exception {
     final JBBPParser parser = JBBPParser.prepare("short k; var; int;");

--- a/src/test/java/com/igormaznitsa/jbbp/compiler/JBBPCompilerTest.java
+++ b/src/test/java/com/igormaznitsa/jbbp/compiler/JBBPCompilerTest.java
@@ -364,6 +364,22 @@ public class JBBPCompilerTest {
   }
 
   @Test
+  public void testCompile_SingleNonamedPackedDecimalDefaultLenField() throws Exception {
+    final byte[] compiled = JBBPCompiler.compile("bcd;").getCompiledData();
+    assertEquals(2, compiled.length);
+    assertEquals(JBBPCompiler.CODE_BCD, compiled[0]);
+    assertEquals(1, compiled[1]);
+  }
+
+  @Test
+  public void testCompile_SingleNonamedPackedDecimalDefinedLenField() throws Exception {
+    final byte[] compiled = JBBPCompiler.compile("bcd:10;").getCompiledData();
+    assertEquals(2, compiled.length);
+    assertEquals(JBBPCompiler.CODE_BCD, compiled[0]);
+    assertEquals(10, compiled[1]);
+  }
+
+  @Test
   public void testCompile_SingleNamedIntField() throws Exception {
     final JBBPCompiledBlock block = JBBPCompiler.compile("int HeLLo;");
     final byte[] compiled = block.getCompiledData();

--- a/src/test/java/com/igormaznitsa/jbbp/compiler/tokenizer/JBBPTokenizerTest.java
+++ b/src/test/java/com/igormaznitsa/jbbp/compiler/tokenizer/JBBPTokenizerTest.java
@@ -543,6 +543,7 @@ public class JBBPTokenizerTest {
             "  // test\n"
             + "  int; \n"
             + "  boolean a;\n"
+            + "  bcd:10 dec;\n"
             + "  byte [1024] array ; \n"
             + "  header {\n"
             + "	    long id;\n"
@@ -553,6 +554,7 @@ public class JBBPTokenizerTest {
     assertParsedItem(iterator.next(), JBBPTokenType.COMMENT, null, null, "test");
     assertParsedItem(iterator.next(), JBBPTokenType.ATOM, "int", null, null);
     assertParsedItem(iterator.next(), JBBPTokenType.ATOM, "boolean", null, "a");
+    assertParsedItem(iterator.next(), JBBPTokenType.ATOM, "bcd:10", null, "dec");
     assertParsedItem(iterator.next(), JBBPTokenType.ATOM, "byte", "1024", "array");
     assertParsedItem(iterator.next(), JBBPTokenType.STRUCT_START, null, null, "header" );
     assertParsedItem(iterator.next(), JBBPTokenType.ATOM, "long", null, "id");

--- a/src/test/java/com/igormaznitsa/jbbp/io/JBBPOutTest.java
+++ b/src/test/java/com/igormaznitsa/jbbp/io/JBBPOutTest.java
@@ -302,6 +302,26 @@ public class JBBPOutTest {
   }
 
   @Test
+  public void testPackedDecimal_BigEndian() throws Exception {
+    assertArrayEquals(new byte[]{0x01, 0x31, 0x17, 0x68, 0x46, 0x77, 0x32, 0x15, 0x56, 0x13}, BeginBin().PackedDecimal(10, 1311768467732155613L).End().toByteArray());
+    assertArrayEquals(new byte[]{0x13, 0x11, 0x76, (byte)0x84, 0x67, 0x73, 0x21, 0x55, 0x61, 0x3C}, BeginBin(JBBPPackedDecimalType.SIGNED).PackedDecimal(10, 1311768467732155613L).End().toByteArray());
+    assertArrayEquals(new byte[]{0x13, 0x11, 0x76, (byte)0x84, 0x67, 0x73, 0x21, 0x55, 0x61, 0x3D}, BeginBin(JBBPPackedDecimalType.SIGNED).PackedDecimal(10, -1311768467732155613L).End().toByteArray());
+  }
+
+  @Test
+  public void testPackedDecimal_LittleEndian() throws Exception {
+    assertArrayEquals(new byte[]{0x01, 0x31, 0x17, 0x68, 0x46, 0x77, 0x32, 0x15, 0x56, 0x13}, BeginBin(JBBPByteOrder.LITTLE_ENDIAN).PackedDecimal(10, 1311768467732155613L).End().toByteArray());
+    assertArrayEquals(new byte[]{0x13, 0x11, 0x76, (byte)0x84, 0x67, 0x73, 0x21, 0x55, 0x61, 0x3C}, BeginBin(JBBPByteOrder.LITTLE_ENDIAN).PackedDecimalType(JBBPPackedDecimalType.SIGNED).PackedDecimal(10, 1311768467732155613L).End().toByteArray());
+    assertArrayEquals(new byte[]{0x13, 0x11, 0x76, (byte)0x84, 0x67, 0x73, 0x21, 0x55, 0x61, 0x3D}, BeginBin(JBBPByteOrder.LITTLE_ENDIAN).PackedDecimalType(JBBPPackedDecimalType.SIGNED).PackedDecimal(10, -1311768467732155613L).End().toByteArray());
+  }
+
+  @Test
+  public void testPackedDecimalArray() throws Exception {
+    assertArrayEquals(new byte[]{(byte)0x99, (byte)0x99, 0x00, 0x00, 0x00, 0x11}, BeginBin().PackedDecimal(2, 9999, 0, 11).End().toByteArray());
+    assertArrayEquals(new byte[]{(byte)0x99, (byte)0x9D, 0x00, 0x0C, 0x12, 0x3C}, BeginBin(JBBPPackedDecimalType.SIGNED).PackedDecimal(2, -999, 0, 123).End().toByteArray());
+  }
+
+  @Test
   public void testDouble_BigEndian() throws Exception {
     final long dbl = Double.doubleToLongBits(Double.MAX_VALUE);
     final byte[] array = BeginBin().ByteOrder(JBBPByteOrder.BIG_ENDIAN).Double(Double.MAX_VALUE).End().toByteArray();

--- a/src/test/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayPackedDecimalTest.java
+++ b/src/test/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayPackedDecimalTest.java
@@ -1,0 +1,74 @@
+package com.igormaznitsa.jbbp.model;
+
+import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class JBBPFieldArrayPackedDecimalTest {
+  private final long [] array = new long[]{-278349872364L, 12223423987439324L, 0L, -2782346872343L, 37238468273412L};
+  private final JBBPFieldArrayPackedDecimal test = new JBBPFieldArrayPackedDecimal(new JBBPNamedFieldInfo("test.field", "field", 999), array);
+
+  @Test
+  public void testNameAndOffset() {
+    assertEquals("test.field", test.getFieldPath());
+    assertEquals("field", test.getFieldName());
+    assertNotNull(test.getNameInfo());
+    assertEquals(999, test.getNameInfo().getFieldOffsetInCompiledBlock());
+  }
+
+  @Test
+  public void testSize() {
+    assertEquals(5, test.size());
+  }
+
+  @Test
+  public void testGetArray() {
+    assertArrayEquals(new long[]{-278349872364L, 12223423987439324L, 0L, -2782346872343L, 37238468273412L}, test.getArray());
+  }
+
+  @Test
+  public void testGetAsBool() {
+    final boolean[] etalon = new boolean[]{true, true, false, true, true};
+    for (int i = 0; i < etalon.length; i++) {
+      assertEquals(etalon[i], test.getAsBool(i));
+    }
+  }
+
+  @Test
+  public void testGetAsInt() {
+    final int[] etalon = new int[]{(int)-278349872364L, (int)12223423987439324L, (int)0L, (int)-2782346872343L, (int)37238468273412L};
+    for (int i = 0; i < etalon.length; i++) {
+      assertEquals(etalon[i], test.getAsInt(i));
+    }
+  }
+
+  @Test
+  public void testGetAsLong() {
+    final long[] etalon = new long[]{-278349872364L, 12223423987439324L, 0L, -2782346872343L, 37238468273412L};
+    for (int i = 0; i < etalon.length; i++) {
+      assertEquals(etalon[i], test.getAsLong(i));
+    }
+  }
+
+  @Test
+  public void testIterable() {
+    final long[] etalon = new long[]{-278349872364L, 12223423987439324L, 0L, -2782346872343L, 37238468273412L};
+    int index = 0;
+    for (final JBBPFieldPackedDecimal f : test) {
+      assertEquals(etalon[index++], f.getAsLong());
+    }
+  }
+
+  @Test
+  public void testGetValueArrayAsObject() {
+    assertArrayEquals(array, (long[]) test.getValueArrayAsObject(false));
+
+    final long[] inverted = (long[]) test.getValueArrayAsObject(true);
+    assertEquals(array.length, inverted.length);
+    for (int i = 0; i < array.length; i++) {
+      assertEquals(JBBPFieldPackedDecimal.reverseBits(array[i]), inverted[i]);
+    }
+  }
+
+}

--- a/src/test/java/com/igormaznitsa/jbbp/model/JBBPFieldPackedDecimalTest.java
+++ b/src/test/java/com/igormaznitsa/jbbp/model/JBBPFieldPackedDecimalTest.java
@@ -1,0 +1,45 @@
+package com.igormaznitsa.jbbp.model;
+
+import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class JBBPFieldPackedDecimalTest {
+
+  @Test
+  public void testNameField() {
+    final JBBPFieldPackedDecimal field = new JBBPFieldPackedDecimal(new JBBPNamedFieldInfo("test.field", "field", 123), 123456L);
+    final JBBPNamedFieldInfo namedField = field.getNameInfo();
+    assertEquals("test.field", namedField.getFieldPath());
+    assertEquals("field", namedField.getFieldName());
+    assertEquals(123, namedField.getFieldOffsetInCompiledBlock());
+  }
+
+  @Test
+  public void testgetAsBool_True() {
+    assertTrue(new JBBPFieldPackedDecimal(new JBBPNamedFieldInfo("test.field", "field", 123), 32423L).getAsBool());
+  }
+
+  @Test
+  public void testgetAsBool_False() {
+    assertFalse(new JBBPFieldPackedDecimal(new JBBPNamedFieldInfo("test.field", "field", 123), 0L).getAsBool());
+  }
+
+  @Test
+  public void testgetAsInt() {
+    assertEquals((int)23432498237439L, new JBBPFieldPackedDecimal(new JBBPNamedFieldInfo("test.field", "field", 123), 23432498237439L).getAsInt());
+    assertEquals((int)-2343249987234L, new JBBPFieldPackedDecimal(new JBBPNamedFieldInfo("test.field", "field", 123), -2343249987234L).getAsInt());
+  }
+
+  @Test
+  public void testgetAsLong() {
+    assertEquals(23432498237439L, new JBBPFieldPackedDecimal(new JBBPNamedFieldInfo("test.field", "field", 123), 23432498237439L).getAsLong());
+    assertEquals(-2343249987234L, new JBBPFieldPackedDecimal(new JBBPNamedFieldInfo("test.field", "field", 123), -2343249987234L).getAsLong());
+  }
+
+  @Test
+  public void testGetAsInvertedBitOrder() {
+    assertEquals(0x10E060A020C04080L, new JBBPFieldPackedDecimal(new JBBPNamedFieldInfo("test.field", "field", 123), 0x0102030405060708L).getAsInvertedBitOrder());
+  }
+}

--- a/src/test/java/com/igormaznitsa/jbbp/utils/PackedDecimalUtilsTest.java
+++ b/src/test/java/com/igormaznitsa/jbbp/utils/PackedDecimalUtilsTest.java
@@ -1,0 +1,100 @@
+package com.igormaznitsa.jbbp.utils;
+
+import com.igormaznitsa.jbbp.exceptions.JBBPOutException;
+import com.igormaznitsa.jbbp.io.JBBPPackedDecimalType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class PackedDecimalUtilsTest {
+
+  PackedDecimalUtils pdUtils = new PackedDecimalUtils();
+
+  @Test
+  public void testReadPackedDecimal_Unsigned() throws Exception {
+
+    // test Long.MAX_VALUE, with and without trailing UNSIGNED nibble
+    assertEquals(9223372036854775807L, pdUtils.readValueFromPackedDecimal(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, 0x7F}, JBBPPackedDecimalType.UNSIGNED));
+    assertEquals(9223372036854775807L, pdUtils.readValueFromPackedDecimal(new byte[]{0x09, 0x22, 0x33, 0x72, 0x03, 0x68, 0x54, 0x77, 0x58, 0x07}, JBBPPackedDecimalType.UNSIGNED));
+
+    // test other values for sign (ignored)
+    assertEquals(1L, pdUtils.readValueFromPackedDecimal(new byte[]{0x0, 0x1A}, JBBPPackedDecimalType.UNSIGNED));
+    assertEquals(1L, pdUtils.readValueFromPackedDecimal(new byte[]{0x0, 0x1B}, JBBPPackedDecimalType.UNSIGNED));
+    assertEquals(1L, pdUtils.readValueFromPackedDecimal(new byte[]{0x0, 0x1C}, JBBPPackedDecimalType.UNSIGNED));
+    assertEquals(1L, pdUtils.readValueFromPackedDecimal(new byte[]{0x0, 0x1D}, JBBPPackedDecimalType.UNSIGNED));
+    assertEquals(1L, pdUtils.readValueFromPackedDecimal(new byte[]{0x0, 0x1E}, JBBPPackedDecimalType.UNSIGNED));
+
+    // test leading zeroes
+    assertEquals(1L, pdUtils.readValueFromPackedDecimal(new byte[]{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x01}, JBBPPackedDecimalType.UNSIGNED));
+
+    // test 0
+    assertEquals(0L, pdUtils.readValueFromPackedDecimal(new byte[]{0x0F}, JBBPPackedDecimalType.UNSIGNED));
+  }
+
+  @Test
+  public void testReadPackedDecimal_Signed() throws Exception {
+    // test all positive sign values (0xA, 0xC, 0xE, 0xF)
+    assertEquals(9223372036854775807L, pdUtils.readValueFromPackedDecimal(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, 0x7A}, JBBPPackedDecimalType.SIGNED));
+    assertEquals(9223372036854775807L, pdUtils.readValueFromPackedDecimal(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, 0x7C}, JBBPPackedDecimalType.SIGNED));
+    assertEquals(9223372036854775807L, pdUtils.readValueFromPackedDecimal(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, 0x7E}, JBBPPackedDecimalType.SIGNED));
+    assertEquals(9223372036854775807L, pdUtils.readValueFromPackedDecimal(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, 0x7F}, JBBPPackedDecimalType.SIGNED));
+
+    // test all negative sign values (0xB, 0xD)
+    assertEquals(-9223372036854775808L, pdUtils.readValueFromPackedDecimal(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, (byte)0x8B}, JBBPPackedDecimalType.SIGNED));
+    assertEquals(-9223372036854775808L, pdUtils.readValueFromPackedDecimal(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, (byte)0x8D}, JBBPPackedDecimalType.SIGNED));
+
+    // positive 1, 0
+    assertEquals(1L, pdUtils.readValueFromPackedDecimal(new byte[]{0x0, 0x1C}, JBBPPackedDecimalType.SIGNED));
+    assertEquals(0L, pdUtils.readValueFromPackedDecimal(new byte[]{0x0, 0x0C}, JBBPPackedDecimalType.SIGNED));
+
+    // negative 1, 0
+    assertEquals(-1L, pdUtils.readValueFromPackedDecimal(new byte[]{0x0, 0x1D}, JBBPPackedDecimalType.SIGNED));
+    assertEquals(0L, pdUtils.readValueFromPackedDecimal(new byte[]{0x0, 0x0D}, JBBPPackedDecimalType.SIGNED));
+  }
+
+  @Test(expected = NumberFormatException.class)
+  public void testReadPackedDecimal_Unsigned_OutOfRange() throws Exception {
+    pdUtils.readValueFromPackedDecimal(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, (byte)0x8F}, JBBPPackedDecimalType.UNSIGNED);
+  }
+
+  @Test(expected = NumberFormatException.class)
+  public void testReadPackedDecimal_Signed_OutOfRange_High() throws Exception {
+    pdUtils.readValueFromPackedDecimal(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, (byte)0x8C}, JBBPPackedDecimalType.SIGNED);
+  }
+
+  @Test(expected = NumberFormatException.class)
+  public void testReadPackedDecimal_Signed_OutOfRange_Low() throws Exception {
+    pdUtils.readValueFromPackedDecimal(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, (byte)0x9D}, JBBPPackedDecimalType.SIGNED);
+  }
+
+  @Test
+  public void testWritePackedDecimal_Unsigned() throws Exception {
+    assertArrayEquals(new byte[]{0x09, 0x22, 0x33, 0x72, 0x03, 0x68, 0x54, 0x77, 0x58, 0x07}, pdUtils.writeValueToPackedDecimal(10, 9223372036854775807L, JBBPPackedDecimalType.UNSIGNED));
+    assertArrayEquals(new byte[]{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x01}, pdUtils.writeValueToPackedDecimal(10, 1, JBBPPackedDecimalType.UNSIGNED));
+    assertArrayEquals(new byte[]{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x00}, pdUtils.writeValueToPackedDecimal(10, 0, JBBPPackedDecimalType.UNSIGNED));
+    assertArrayEquals(new byte[]{(byte)0x99, (byte)0x99}, pdUtils.writeValueToPackedDecimal(2, 9999, JBBPPackedDecimalType.UNSIGNED));
+  }
+
+  @Test
+  public void testWritePackedDecimal_Signed() throws Exception {
+    assertArrayEquals(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, 0x7C}, pdUtils.writeValueToPackedDecimal(10, 9223372036854775807L, JBBPPackedDecimalType.SIGNED));
+    assertArrayEquals(new byte[]{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1C}, pdUtils.writeValueToPackedDecimal(10, 1, JBBPPackedDecimalType.SIGNED));
+    assertArrayEquals(new byte[]{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0C}, pdUtils.writeValueToPackedDecimal(10, 0, JBBPPackedDecimalType.SIGNED));
+    assertArrayEquals(new byte[]{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1D}, pdUtils.writeValueToPackedDecimal(10, -1L, JBBPPackedDecimalType.SIGNED));
+    assertArrayEquals(new byte[]{(byte)0x92, 0x23, 0x37, 0x20, 0x36, (byte)0x85, 0x47, 0x75, (byte)0x80, (byte)0x8D}, pdUtils.writeValueToPackedDecimal(10, -9223372036854775808L, JBBPPackedDecimalType.SIGNED));
+    assertArrayEquals(new byte[]{0x1C}, pdUtils.writeValueToPackedDecimal(1, 1, JBBPPackedDecimalType.SIGNED));
+    assertArrayEquals(new byte[]{0x0C}, pdUtils.writeValueToPackedDecimal(1, 0, JBBPPackedDecimalType.SIGNED));
+    assertArrayEquals(new byte[]{0x1D}, pdUtils.writeValueToPackedDecimal(1, -1, JBBPPackedDecimalType.SIGNED));
+  }
+
+  @Test(expected = JBBPOutException.class)
+  public void testWritePackedDecimal_WrongSign() throws Exception {
+    pdUtils.writeValueToPackedDecimal(10, -1L, JBBPPackedDecimalType.UNSIGNED);
+  }
+
+  @Test(expected = JBBPOutException.class)
+  public void testWritePackedDecimal_Overflow() throws Exception {
+    pdUtils.writeValueToPackedDecimal(1, 100L, JBBPPackedDecimalType.UNSIGNED);
+  }
+}


### PR DESCRIPTION
Hello,
Very cool library!  I have run across lots of binary message formats that include [binary coded decimal (aka packed decimal)](http://en.wikipedia.org/wiki/Binary-coded_decimal#Packed_BCD)...including one I need to support on my current project.  So I spent a few hours yesterday and most of today adding BCD support (signed and unsigned) as a field type in the parsing DSL.  I added tests for everything I did, and the existing tests are all passing.  I hope you'll consider accepting this contribution!  

This is not quite complete, as I don't yet have support for BCD using your `@Bin` annotation.  I just ran out of time today, and need to work on something else the rest of the week.  I can finish it up later, but would appreciate some pointers on what needs to be done.
