### PR TITLE
Ability to convert parsed structure to Map<String, Object>

### DIFF
--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPAbstractField.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPAbstractField.java
@@ -17,12 +17,13 @@ package com.igormaznitsa.jbbp.model;
 
 import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
 import java.io.Serializable;
+import java.util.Map;
 
 /**
  * The Class is the ancestor for all fields and arrays of fields.
  * @since 1.0
  */
-public class JBBPAbstractField implements Serializable {
+public abstract class JBBPAbstractField implements Serializable {
   private static final long serialVersionUID = 8142829902016660630L;
   
   /**
@@ -45,7 +46,55 @@ public class JBBPAbstractField implements Serializable {
   public JBBPNamedFieldInfo getNameInfo(){
     return this.fieldNameInfo;
   }
-  
+
+  /**
+   * Get key in order to store in a {@link Map}.  If the field is named, the name is
+   * returned as the key, otherwise a key is generated based on the field type and
+   * the index within the enclosing array of fields.
+   *
+   * @param index the index of the field within the enclosing array of fields
+   * @return the key
+   */
+  protected String getKey(int index) {
+
+    if (getNameInfo() != null) {
+      return getNameInfo().getFieldName();
+    } else {
+      return getKeyPrefix() + "_" + index;
+    }
+  }
+
+  /**
+   * Returns the key prefix used for generated keys.
+   *
+   * @return the key prefix
+   */
+  protected abstract String getKeyPrefix();
+
+  /**
+   * Returns an object representation of the field and its children.  The intent
+   * of this method is to produce a hierarchy consisting only of Java primitive
+   * Objects (e.g., Boolean, Long, Integer, String) and collection (e.g., Map,
+   * List) classes that can be converted to other representations, such as JSON
+   * or XML.  The contract for the return Object is as follows:
+   *
+   * <ul>
+   *   <li>{@link java.lang.Boolean} - for <code>bool</code> fields</li>
+   *   <li>extending from {@link java.lang.Number} - for numeric fields (i.e.,
+   *   <code>bit, byte, ubyte, short, ushort, int, long</code>, or other numeric
+   *   custom fields)</li>
+   *   <li>{@link java.lang.String} - for custom fields that read strings</li>
+   *   <li>{@link java.util.List} - for arrays of primitive types</li>
+   *   <li>{@link java.util.Map} - for structs that contain other structs and/or
+   *   fields</li>
+   * </ul>
+   *
+   * New custom field types must adhere to this contract.
+   *
+   * @return the value object
+   */
+  protected abstract Object getValue();
+
   /**
    * Get the field path.
    * @return the field path or null if the field doesn't contain any field name info

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayBit.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayBit.java
@@ -19,6 +19,9 @@ import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
 import com.igormaznitsa.jbbp.io.JBBPBitNumber;
 import com.igormaznitsa.jbbp.utils.JBBPUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Describes an array contains bit fields.
  * @since 1.0
@@ -59,6 +62,20 @@ public final class JBBPFieldArrayBit extends JBBPAbstractArrayField<JBBPFieldBit
    */
   public byte[] getArray() {
     return this.array.clone();
+  }
+
+  @Override
+  protected String getKeyPrefix() {
+    return "array_bit";
+  }
+
+  @Override
+  protected Object getValue() {
+    List<Object> valueList = new ArrayList<Object>();
+    for (byte b : getArray()) {
+      valueList.add((int)b);
+    }
+    return valueList;
   }
 
   /**

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayBoolean.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayBoolean.java
@@ -18,6 +18,9 @@ package com.igormaznitsa.jbbp.model;
 import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
 import com.igormaznitsa.jbbp.utils.JBBPUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Describes an array of boolean values.
  * @since 1.0
@@ -39,7 +42,6 @@ public final class JBBPFieldArrayBoolean extends JBBPAbstractArrayField<JBBPFiel
     JBBPUtils.assertNotNull(array, "Array must not be null");
     this.array = array;
   }
-  
   /**
    * Get values of the array.
    * @return values as a boolean array
@@ -47,7 +49,21 @@ public final class JBBPFieldArrayBoolean extends JBBPAbstractArrayField<JBBPFiel
   public boolean [] getArray(){
     return this.array.clone();
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "array_boolean";
+  }
+
+  @Override
+  protected Object getValue() {
+    List<Object> valueList = new ArrayList<Object>();
+    for (boolean bool : getArray()) {
+      valueList.add(bool);
+    }
+    return valueList;
+  }
+
   @Override
   public int size() {
     return this.array.length;

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayByte.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayByte.java
@@ -17,6 +17,9 @@ package com.igormaznitsa.jbbp.model;
 
 import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Describes a byte array.
  * @since 1.0
@@ -39,6 +42,20 @@ public final class JBBPFieldArrayByte extends AbstractFieldByteArray<JBBPFieldBy
    */
   public byte[] getArray(){
     return this.array.clone();
+  }
+
+  @Override
+  protected String getKeyPrefix() {
+    return "array_byte";
+  }
+
+  @Override
+  protected Object getValue() {
+    List<Object> valueList = new ArrayList<Object>();
+    for (byte b : getArray()) {
+      valueList.add((int)b);
+    }
+    return valueList;
   }
 
   @Override

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayInt.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayInt.java
@@ -18,6 +18,9 @@ package com.igormaznitsa.jbbp.model;
 import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
 import com.igormaznitsa.jbbp.utils.JBBPUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Describes an array of integers.
  * @since 1.0
@@ -47,7 +50,21 @@ public final class JBBPFieldArrayInt extends JBBPAbstractArrayField<JBBPFieldInt
   public int [] getArray(){
     return this.array.clone();
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "array_int";
+  }
+
+  @Override
+  protected Object getValue() {
+    List<Object> valueList = new ArrayList<Object>();
+    for (int i : getArray()) {
+      valueList.add(i);
+    }
+    return valueList;
+  }
+
   @Override
   public int size() {
     return this.array.length;

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayLong.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayLong.java
@@ -18,6 +18,9 @@ package com.igormaznitsa.jbbp.model;
 import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
 import com.igormaznitsa.jbbp.utils.JBBPUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Describes a long array.
  * @since 1.0
@@ -46,6 +49,20 @@ public final class JBBPFieldArrayLong extends JBBPAbstractArrayField<JBBPFieldLo
    */
   public long [] getArray(){
     return this.array.clone();
+  }
+
+  @Override
+  protected String getKeyPrefix() {
+    return "array_long";
+  }
+
+  @Override
+  protected Object getValue() {
+    List<Object> valueList = new ArrayList<Object>();
+    for (long l : getArray()) {
+      valueList.add(l);
+    }
+    return valueList;
   }
 
   @Override

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayShort.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayShort.java
@@ -18,6 +18,9 @@ package com.igormaznitsa.jbbp.model;
 import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
 import com.igormaznitsa.jbbp.utils.JBBPUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Describes a short array.
  * @since 1.0
@@ -47,7 +50,21 @@ public final class JBBPFieldArrayShort extends JBBPAbstractArrayField<JBBPFieldS
   public short [] getArray(){
     return this.array.clone();
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "array_short";
+  }
+
+  @Override
+  protected Object getValue() {
+    List<Object> valueList = new ArrayList<Object>();
+    for (short sh : getArray()) {
+      valueList.add((int)sh);
+    }
+    return valueList;
+  }
+
   @Override
   public int size() {
     return this.array.length;

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayStruct.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayStruct.java
@@ -18,6 +18,9 @@ package com.igormaznitsa.jbbp.model;
 import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
 import com.igormaznitsa.jbbp.utils.JBBPUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Describes a structure array. It doesn't support operations to get an array value as a numeric one.
  * @since 1.0
@@ -47,7 +50,21 @@ public final class JBBPFieldArrayStruct extends JBBPAbstractArrayField<JBBPField
   public JBBPFieldStruct [] getArray(){
     return this.structs.clone();
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "array_struct";
+  }
+
+  @Override
+  protected Object getValue() {
+    List<Object> valueList = new ArrayList<Object>();
+    for (JBBPFieldStruct struct : getArray()) {
+      valueList.add(struct.getValue());
+    }
+    return valueList;
+  }
+
   @Override
   public int size() {
     return this.structs.length;

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayUByte.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayUByte.java
@@ -17,6 +17,9 @@ package com.igormaznitsa.jbbp.model;
 
 import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Describes a unsigned byte array.
  * @since 1.0
@@ -40,7 +43,21 @@ public final class JBBPFieldArrayUByte extends AbstractFieldByteArray<JBBPFieldU
   public byte [] getArray(){
     return this.array.clone();
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "array_ubyte";
+  }
+
+  @Override
+  protected Object getValue() {
+    List<Object> valueList = new ArrayList<Object>();
+    for (int i = 0; i < size(); i++) {
+      valueList.add(getAsInt(i));
+    }
+    return valueList;
+  }
+
   @Override
   public int size() {
     return this.array.length;

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayUShort.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldArrayUShort.java
@@ -18,6 +18,9 @@ package com.igormaznitsa.jbbp.model;
 import com.igormaznitsa.jbbp.compiler.JBBPNamedFieldInfo;
 import com.igormaznitsa.jbbp.utils.JBBPUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Describes a unsigned short array.
  * @since 1.0
@@ -46,6 +49,20 @@ public final class JBBPFieldArrayUShort extends JBBPAbstractArrayField<JBBPField
    */
   public short [] getArray() {
     return this.array.clone();
+  }
+
+  @Override
+  protected String getKeyPrefix() {
+    return "array_ushort";
+  }
+
+  @Override
+  protected Object getValue() {
+    List<Object> valueList = new ArrayList<Object>();
+    for (int i = 0; i < size(); i++) {
+      valueList.add(getAsInt(i));
+    }
+    return valueList;
   }
 
   @Override

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldBit.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldBit.java
@@ -47,7 +47,17 @@ public final class JBBPFieldBit extends JBBPAbstractField implements JBBPNumeric
     this.bitNumber = bitNumber;
     this.value = value;
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "field_bit";
+  }
+
+  @Override
+  protected Object getValue() {
+    return getAsInt();
+  }
+
   /**
    * Get number of valuable bits in the value. It plays informative role and doesn't play role during numeric value getting.
    * @return the number of valuable bits in the value.

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldBoolean.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldBoolean.java
@@ -38,6 +38,16 @@ public final class JBBPFieldBoolean extends JBBPAbstractField implements JBBPNum
     this.value = value;
   }
 
+  @Override
+  protected String getKeyPrefix() {
+    return "field_boolean";
+  }
+
+  @Override
+  protected Object getValue() {
+    return this.value;
+  }
+
   public int getAsInt() {
     return this.value ? 1 : 0;
   }

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldByte.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldByte.java
@@ -38,7 +38,17 @@ public final class JBBPFieldByte extends JBBPAbstractField implements JBBPNumeri
     super(name);
     this.value = value;
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "field_byte";
+  }
+
+  @Override
+  protected Object getValue() {
+    return getAsInt();
+  }
+
   public int getAsInt() {
     return this.value;
   }

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldInt.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldInt.java
@@ -38,7 +38,17 @@ public final class JBBPFieldInt extends JBBPAbstractField implements JBBPNumeric
     super(name);
     this.value = value;
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "field_int";
+  }
+
+  @Override
+  protected Object getValue() {
+    return getAsInt();
+  }
+
   public int getAsInt() {
     return this.value;
   }

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldLong.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldLong.java
@@ -38,7 +38,17 @@ public final class JBBPFieldLong extends JBBPAbstractField implements JBBPNumeri
     super(name);
     this.value = value;
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "field_long";
+  }
+
+  @Override
+  protected Object getValue() {
+    return getAsLong();
+  }
+
   public int getAsInt() {
     return (int)this.value;
   }

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldShort.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldShort.java
@@ -38,7 +38,17 @@ public final class JBBPFieldShort extends JBBPAbstractField implements JBBPNumer
     super(name);
     this.value = value;
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "field_short";
+  }
+
+  @Override
+  protected Object getValue() {
+    return getAsInt();
+  }
+
   public int getAsInt() {
     return this.value;
   }

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldStruct.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldStruct.java
@@ -22,7 +22,11 @@ import com.igormaznitsa.jbbp.mapper.JBBPMapper;
 import com.igormaznitsa.jbbp.mapper.JBBPMapperCustomFieldProcessor;
 import com.igormaznitsa.jbbp.model.finder.JBBPFieldFinder;
 import com.igormaznitsa.jbbp.utils.JBBPUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Describes a structure.
@@ -385,4 +389,30 @@ public final class JBBPFieldStruct extends JBBPAbstractField implements JBBPFiel
     return JBBPMapper.map(this, objectToMap, customFieldProcessor, flags);
   }
 
+  @Override
+  protected String getKeyPrefix() {
+    return "field_struct";
+  }
+
+  @Override
+  protected Object getValue() {
+    Map<String, Object> returnMap = new LinkedHashMap<String, Object>();
+    for (int i = 0; i < fields.length; i++) {
+      JBBPAbstractField field = fields[i];
+      returnMap.put(field.getKey(i), field.getValue());
+    }
+    return returnMap;
+  }
+
+  /**
+   * Converts the parsed hierarchy to a {@literal Map<String, Object>}.  The
+   * resulting <code>Map</code> can be easily converted to other data
+   * representations (e.g., JSON, XML).
+   *
+   * @return the map
+   * @see JBBPAbstractField#getValue()
+   */
+  public Map<String, Object> asMap() {
+    return (Map<String, Object>) getValue();
+  }
 }

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldUByte.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldUByte.java
@@ -38,7 +38,17 @@ public final class JBBPFieldUByte extends JBBPAbstractField implements JBBPNumer
     super(name);
     this.value = value;
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "field_ubyte";
+  }
+
+  @Override
+  protected Object getValue() {
+    return getAsInt();
+  }
+
   public int getAsInt() {
     return this.value & 0xFF;
   }

--- a/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldUShort.java
+++ b/src/main/java/com/igormaznitsa/jbbp/model/JBBPFieldUShort.java
@@ -38,7 +38,17 @@ public final class JBBPFieldUShort extends JBBPAbstractField implements JBBPNume
     super(name);
     this.value = value;
   }
-  
+
+  @Override
+  protected String getKeyPrefix() {
+    return "field_ushort";
+  }
+
+  @Override
+  protected Object getValue() {
+    return getAsInt();
+  }
+
   public int getAsInt() {
     return this.value & 0xFFFF;
   }


### PR DESCRIPTION
Hi Igor,

I hope you'll accept this one into the core library.  I think being able to convert the parsed data structure hierarchy to other formats (e.g., JSON, XML) is essential for many use cases.  Most JSON libraries can convert from `Map<String, Object>` to JSON, and there are also libraries to convert from `Map<String, Object>` to XML.  For example, I was able to easily do the following using the [jackson](https://github.com/FasterXML/jackson) library:

```java
    final InputStream pngStream = getResourceAsInputStream("picture.png");
    try {
      final JBBPParser pngParser = JBBPParser.prepare(
              "long header;"
              + "// chunks\n"
              + "chunk [_]{"
              + "   int length; "
              + "   int type; "
              + "   byte[length] data; "
              + "   int crc;"
              + "}"
      );

      final JBBPFieldStruct result = pngParser.parse(pngStream);
      final Map<String, Object> resultMap = result.asMap();

      ObjectMapper mapper = new ObjectMapper();
      JsonNode jsonNode = mapper.valueToTree(resultMap);
      // do something with the JsonNode
    }
    finally {
      JBBPUtils.closeQuietly(pngStream);
    }
  }
```

Also note that these changes only add 3,859 bytes to the size of the library (151,686 vs 147,827).

Thanks!



