### PR TITLE
Better conversion from classes to JBBP format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /jbbp/BenchmarkList
 /jbbp/CompilerHints
 /jbbp/nb-configuration.xml
+target

--- a/jbbp/src/main/java/com/igormaznitsa/jbbp/io/Binary.java
+++ b/jbbp/src/main/java/com/igormaznitsa/jbbp/io/Binary.java
@@ -1,0 +1,95 @@
+package jbbp.io;
+
+import com.igormaznitsa.jbbp.mapper.Bin;
+import com.igormaznitsa.jbbp.mapper.BinType;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public interface Binary {
+    default List<Field> getSortedBinFieldList() {
+        Class clazz = this.getClass();
+
+        Stream<Field> fields = Arrays.stream(clazz.getDeclaredFields());
+
+        Stream<Field> binFields = fields.filter(f -> Arrays.stream(f.getDeclaredAnnotations()).anyMatch(a -> a instanceof Bin));
+
+        Comparator<Bin> binComparator = Comparator.comparing(Bin::outOrder);
+        Comparator<Field> binFieldComparator = Comparator.comparing(f -> f.getDeclaredAnnotation(Bin.class), binComparator);
+
+        Stream<Field> sortedBinFields = binFields.sorted(binFieldComparator);
+
+        List<Field> sortedBinFieldList = sortedBinFields.collect(Collectors.toList());
+
+        return sortedBinFieldList;
+    }
+
+    default String getFormat() {
+        List<Field> sortedBinFields = getSortedBinFieldList();
+
+        String format = sortedBinFields.stream().map(this::getString)
+                .collect(Collectors.joining(" "));
+
+        return format;
+    }
+
+    default String getString(Field field) {
+        try {
+            boolean array = false;
+
+            Class<?> clazz = field.getType();
+
+            if (clazz.isArray()) {
+                array = true;
+                clazz = clazz.getComponentType();
+            }
+
+            StringBuilder stringBuilder = new StringBuilder();
+            String name = field.getName();
+
+            if (Binary.class.isAssignableFrom(clazz)) {
+                // Embedded object
+                stringBuilder.append(name);
+                stringBuilder.append(" ");
+                addArrayIndicatorIfNecessary(array, stringBuilder);
+                stringBuilder.append(" { ");
+                Object a = field.get(this);
+                Object b = clazz.newInstance();
+                stringBuilder.append(((Binary) b).getFormat());
+                stringBuilder.append(" } ");
+            } else {
+                Bin bin = field.getDeclaredAnnotation(Bin.class);
+                BinType binType = bin.type();
+                String arraySize = "_";
+
+                if (!bin.extra().isEmpty()) {
+                    arraySize = bin.extra();
+                }
+
+                String binTypeString = binType.toString().replace("_ARRAY", "[" + arraySize + "]");
+                stringBuilder.append(binTypeString);
+                stringBuilder.append(" ");
+                stringBuilder.append(name);
+                stringBuilder.append(";");
+            }
+
+            return stringBuilder.toString();
+        } catch (IllegalAccessException e) {
+            // THIS IS A BUG
+            throw new UnsupportedOperationException(e);
+        } catch (InstantiationException e) {
+            // THIS IS A BUG
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
+    default void addArrayIndicatorIfNecessary(boolean array, StringBuilder stringBuilder) {
+        if (array) {
+            stringBuilder.append("[_]");
+        }
+    }
+}

--- a/jbbp/src/test/java/com/igormaznitsa/jbbp/benchmarks/JBBP_Benchmark.java
+++ b/jbbp/src/test/java/com/igormaznitsa/jbbp/benchmarks/JBBP_Benchmark.java
@@ -58,7 +58,7 @@ public class JBBP_Benchmark {
 
   @Benchmark
   public void measureParse_Static() throws IOException {
-    new JBBPBenchmarkParser().read(new JBBPBitInputStream(new ByteArrayInputStream(DATA)));
+    parser.parse(new JBBPBitInputStream(new ByteArrayInputStream(DATA)));
   }
 
   public static class InData {

--- a/pom.xml
+++ b/pom.xml
@@ -178,8 +178,8 @@
                 <configuration>
                     <compilerArgument>-Xlint:all</compilerArgument>
                     <verbose>false</verbose>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                 </configuration>


### PR DESCRIPTION
I ran into some trouble a few months back with some code I found to convert from a class to the JBBP representation.  I added an interface with default methods called Binary that you can add to a class.  When you add it to a class you can then call getFormat() on it to get the JBBP format string for the class.

I used Java 8 for this so I could use default methods and not force every class to extend my base class.

I also updated the gitignore to ignore my Java target directories and fixed a test that wasn't compiling for me.  I'm not sure I did the right thing for the test but otherwise I couldn't build it.