### PR TITLE
Fixed broken link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The Framework provides support for arrays and structures. Just keep in mind that
 ![JBBP field format, types and examples](https://github.com/raydac/java-binary-block-parser/blob/master/docs/jbbp_complex_types.png)
 
 ## Custom types
-it is possible to define processors for own custom data types, for instance you can take a look at [case processing three byte unsigned integer types](https://github.com/raydac/java-binary-block-parser/blob/master/src/test/java/com/igormaznitsa/jbbp/it/CustomThreeByteIntegerTypeTest.java).   
+it is possible to define processors for own custom data types, for instance you can take a look at [case processing three byte unsigned integer types](https://github.com/raydac/java-binary-block-parser/blob/master/jbbp/src/test/java/com/igormaznitsa/jbbp/it/CustomThreeByteIntegerTypeTest.java).   
 
 ### Float and Double types
 The Parser does not support Java float and double types out of the box. But it can be implemented through custom type processor. [there is written example and test and the code can be copy pasted](https://github.com/raydac/java-binary-block-parser/blob/master/src/test/java/com/igormaznitsa/jbbp/it/FloatAndDoubleTypesTest.java).


### PR DESCRIPTION
Fixed a broken link to the class that shows the three byte integer parsing example.

BTW, is there an easier way to do this?  I have several values that are 22, 23, or 24 bit integers that are not neatly aligned to byte boundaries.  I want to be able to read them with minimal configuration and custom code.  I think I understand how to do this with values that are less than 8 bits but not with more than 8 bits.